### PR TITLE
Split Chats from Media DB (BREAKING), Mindmap viewing in gradio from PlantUML, token counts for conversations

### DIFF
--- a/App_Function_Libraries/Benchmarks_Evaluations/ms_g_eval.py
+++ b/App_Function_Libraries/Benchmarks_Evaluations/ms_g_eval.py
@@ -24,7 +24,7 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from App_Function_Libraries.Chat import chat_api_call
+from App_Function_Libraries.Chat.Chat_Functions import chat_api_call
 
 #
 #######################################################################################################################

--- a/App_Function_Libraries/Chat/Chat_Functions.py
+++ b/App_Function_Libraries/Chat/Chat_Functions.py
@@ -27,6 +27,16 @@ from App_Function_Libraries.Metrics.metrics_logger import log_counter, log_histo
 #
 # Functions:
 
+def approximate_token_count(history):
+    total_text = ''
+    for user_msg, bot_msg in history:
+        if user_msg:
+            total_text += user_msg + ' '
+        if bot_msg:
+            total_text += bot_msg + ' '
+    total_tokens = len(total_text.split())
+    return total_tokens
+
 def chat_api_call(api_endpoint, api_key, input_data, prompt, temp, system_message=None):
     log_counter("chat_api_call_attempt", labels={"api_endpoint": api_endpoint})
     start_time = time.time()

--- a/App_Function_Libraries/Chat/Chat_Functions.py
+++ b/App_Function_Libraries/Chat/Chat_Functions.py
@@ -1,4 +1,4 @@
-# Chat.py
+# Chat_Functions.py
 # Chat functions for interacting with the LLMs as chatbots
 import base64
 # Imports

--- a/App_Function_Libraries/DB/Character_Chat_DB.py
+++ b/App_Function_Libraries/DB/Character_Chat_DB.py
@@ -560,6 +560,7 @@ def delete_character_chat(chat_id: int) -> bool:
     finally:
         conn.close()
 
+
 def fetch_keywords_for_chats(keywords: List[str]) -> List[int]:
     """
     Fetch chat IDs associated with any of the specified keywords.
@@ -589,15 +590,13 @@ def fetch_keywords_for_chats(keywords: List[str]) -> List[int]:
     finally:
         conn.close()
 
+
 def save_chat_history_to_character_db(character_id: int, conversation_name: str, chat_history: List[Tuple[str, str]]) -> Optional[int]:
     """Save chat history to the CharacterChats table.
 
     Returns the ID of the inserted chat or None if failed.
     """
     return add_character_chat(character_id, conversation_name, chat_history)
-
-def migrate_chat_to_media_db():
-    pass
 
 
 def search_db(query: str, fields: List[str], where_clause: str = "", page: int = 1, results_per_page: int = 5) -> List[Dict[str, Any]]:

--- a/App_Function_Libraries/DB/DB_Manager.py
+++ b/App_Function_Libraries/DB/DB_Manager.py
@@ -28,10 +28,7 @@ from App_Function_Libraries.DB.SQLite_DB import (
     add_prompt as sqlite_add_prompt,
     delete_chat_message as sqlite_delete_chat_message,
     update_chat_message as sqlite_update_chat_message,
-    add_chat_message as sqlite_add_chat_message,
-    get_chat_messages as sqlite_get_chat_messages,
     search_chat_conversations as sqlite_search_chat_conversations,
-    create_chat_conversation as sqlite_create_chat_conversation,
     save_chat_history_to_database as sqlite_save_chat_history_to_database,
     view_database as sqlite_view_database,
     get_transcripts as sqlite_get_transcripts,
@@ -70,13 +67,24 @@ from App_Function_Libraries.DB.SQLite_DB import (
     fetch_paginated_data as sqlite_fetch_paginated_data, get_latest_transcription as sqlite_get_latest_transcription, \
     mark_media_as_processed as sqlite_mark_media_as_processed,
 )
+from App_Function_Libraries.DB.RAG_QA_Chat_DB import start_new_conversation as sqlite_start_new_conversation, \
+    save_message as sqlite_save_message, load_chat_history as sqlite_load_chat_history, \
+    get_all_conversations as sqlite_get_all_conversations, get_notes_by_keywords as sqlite_get_notes_by_keywords, \
+    get_note_by_id as sqlite_get_note_by_id, update_note as sqlite_update_note, save_notes as sqlite_save_notes, \
+    clear_keywords_from_note as sqlite_clear_keywords_from_note, add_keywords_to_note as sqlite_add_keywords_to_note, \
+    add_keywords_to_conversation as sqlite_add_keywords_to_conversation, \
+    get_keywords_for_note as sqlite_get_keywords_for_note, delete_note as sqlite_delete_note, \
+    search_conversations_by_keywords as sqlite_search_conversations_by_keywords, \
+    delete_conversation as sqlite_delete_conversation, get_conversation_title as sqlite_get_conversation_title, \
+    update_conversation_title as sqlite_update_conversation_title, \
+    fetch_all_conversations as sqlite_fetch_all_conversations, fetch_all_notes as sqlite_fetch_all_notes, \
+    fetch_conversations_by_ids as sqlite_fetch_conversations_by_ids, fetch_notes_by_ids as sqlite_fetch_notes_by_ids
 from App_Function_Libraries.DB.Character_Chat_DB import (
     add_character_card as sqlite_add_character_card, get_character_cards as sqlite_get_character_cards, \
     get_character_card_by_id as sqlite_get_character_card_by_id, update_character_card as sqlite_update_character_card, \
     delete_character_card as sqlite_delete_character_card, add_character_chat as sqlite_add_character_chat, \
     get_character_chats as sqlite_get_character_chats, get_character_chat_by_id as sqlite_get_character_chat_by_id, \
-    update_character_chat as sqlite_update_character_chat, delete_character_chat as sqlite_delete_character_chat, \
-    migrate_chat_to_media_db as sqlite_migrate_chat_to_media_db,
+    update_character_chat as sqlite_update_character_chat, delete_character_chat as sqlite_delete_character_chat
 )
 #
 # Local Imports
@@ -735,16 +743,16 @@ def update_chat_message(*args, **kwargs):
         # Implement Elasticsearch version
         raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
 
-def add_chat_message(*args, **kwargs):
+def save_message(*args, **kwargs):
     if db_type == 'sqlite':
-        return sqlite_add_chat_message(*args, **kwargs)
+        return sqlite_save_message(*args, **kwargs)
     elif db_type == 'elasticsearch':
         # Implement Elasticsearch version
         raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
 
-def get_chat_messages(*args, **kwargs):
+def load_chat_history(*args, **kwargs):
     if db_type == 'sqlite':
-        return sqlite_get_chat_messages(*args, **kwargs)
+        return sqlite_load_chat_history(*args, **kwargs)
     elif db_type == 'elasticsearch':
         # Implement Elasticsearch version
         raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
@@ -756,9 +764,9 @@ def search_chat_conversations(*args, **kwargs):
         # Implement Elasticsearch version
         raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
 
-def create_chat_conversation(*args, **kwargs):
+def start_new_conversation(*args, **kwargs):
     if db_type == 'sqlite':
-        return sqlite_create_chat_conversation(*args, **kwargs)
+        return sqlite_start_new_conversation(*args, **kwargs)
     elif db_type == 'elasticsearch':
         # Implement Elasticsearch version
         raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
@@ -773,6 +781,90 @@ def save_chat_history_to_database(*args, **kwargs):
 def get_conversation_name(*args, **kwargs):
     if db_type == 'sqlite':
         return sqlite_get_conversation_name(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def get_all_conversations(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_get_all_conversations(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def get_notes_by_keywords(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_get_notes_by_keywords(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def get_note_by_id(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_get_note_by_id(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def add_keywords_to_conversation(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_add_keywords_to_conversation(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def get_keywords_for_note(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_get_keywords_for_note(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def delete_note(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_delete_note(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def search_conversations_by_keywords(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_search_conversations_by_keywords(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def delete_conversation(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_delete_conversation(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def get_conversation_title(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_get_conversation_title(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def update_conversation_title(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_update_conversation_title(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def fetch_all_conversations(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_fetch_all_conversations()
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def fetch_all_notes(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_fetch_all_notes()
     elif db_type == 'elasticsearch':
         # Implement Elasticsearch version
         raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
@@ -856,12 +948,54 @@ def delete_character_chat(*args, **kwargs):
         # Implement Elasticsearch version
         raise NotImplementedError("Elasticsearch version of delete_character_chat not yet implemented")
 
-def migrate_chat_to_media_db(*args, **kwargs):
+def update_note(*args, **kwargs):
     if db_type == 'sqlite':
-        return sqlite_migrate_chat_to_media_db(*args, **kwargs)
+        return sqlite_update_note(*args, **kwargs)
     elif db_type == 'elasticsearch':
         # Implement Elasticsearch version
-        raise NotImplementedError("Elasticsearch version of migrate_chat_to_media_db not yet implemented")
+        raise NotImplementedError("Elasticsearch version of update_note not yet implemented")
+
+def save_notes(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_save_notes(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of save_notes not yet implemented")
+
+def clear_keywords(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_clear_keywords_from_note(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of clear_keywords not yet implemented")
+
+def clear_keywords_from_note(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_clear_keywords_from_note(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of clear_keywords_from_note not yet implemented")
+
+def add_keywords_to_note(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_add_keywords_to_note(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of add_keywords_to_note not yet implemented")
+
+def fetch_conversations_by_ids(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_fetch_conversations_by_ids(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of fetch_conversations_by_ids not yet implemented")
+
+def fetch_notes_by_ids(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_fetch_notes_by_ids(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of fetch_notes_by_ids not yet implemented")
 
 #
 # End of Character Chat-related Functions

--- a/App_Function_Libraries/DB/DB_Manager.py
+++ b/App_Function_Libraries/DB/DB_Manager.py
@@ -78,7 +78,8 @@ from App_Function_Libraries.DB.RAG_QA_Chat_DB import start_new_conversation as s
     delete_conversation as sqlite_delete_conversation, get_conversation_title as sqlite_get_conversation_title, \
     update_conversation_title as sqlite_update_conversation_title, \
     fetch_all_conversations as sqlite_fetch_all_conversations, fetch_all_notes as sqlite_fetch_all_notes, \
-    fetch_conversations_by_ids as sqlite_fetch_conversations_by_ids, fetch_notes_by_ids as sqlite_fetch_notes_by_ids
+    fetch_conversations_by_ids as sqlite_fetch_conversations_by_ids, fetch_notes_by_ids as sqlite_fetch_notes_by_ids, \
+    delete_messages_in_conversation as sqlite_delete_messages_in_conversation
 from App_Function_Libraries.DB.Character_Chat_DB import (
     add_character_card as sqlite_add_character_card, get_character_cards as sqlite_get_character_cards, \
     get_character_card_by_id as sqlite_get_character_card_by_id, update_character_card as sqlite_update_character_card, \
@@ -868,6 +869,13 @@ def fetch_all_notes(*args, **kwargs):
     elif db_type == 'elasticsearch':
         # Implement Elasticsearch version
         raise NotImplementedError("Elasticsearch version of add_media_with_keywords not yet implemented")
+
+def delete_messages_in_conversation(*args, **kwargs):
+    if db_type == 'sqlite':
+        return sqlite_delete_messages_in_conversation(*args, **kwargs)
+    elif db_type == 'elasticsearch':
+        # Implement Elasticsearch version
+        raise NotImplementedError("Elasticsearch version of delete_messages_in_conversation not yet implemented")
 
 #
 # End of Chat-related Functions

--- a/App_Function_Libraries/DB/RAG_QA_Chat_DB.py
+++ b/App_Function_Libraries/DB/RAG_QA_Chat_DB.py
@@ -58,7 +58,8 @@ CREATE TABLE IF NOT EXISTS conversation_metadata (
     conversation_id TEXT PRIMARY KEY,
     created_at DATETIME NOT NULL,
     last_updated DATETIME NOT NULL,
-    title TEXT NOT NULL
+    title TEXT NOT NULL,
+    media_id INTEGER
 );
 
 -- Table for storing keywords

--- a/App_Function_Libraries/DB/SQLite_DB.py
+++ b/App_Function_Libraries/DB/SQLite_DB.py
@@ -341,6 +341,7 @@ def create_tables(db) -> None:
             FOREIGN KEY (media_id) REFERENCES Media(id)
         )
         ''',
+        # This is to be deleted - FIXME
         '''
         CREATE TABLE IF NOT EXISTS ChatConversations (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2023,8 +2024,6 @@ def import_obsidian_note_to_db(note_data):
 #######################################################################################################################
 #
 # Chat-related Functions
-
-
 
 def create_chat_conversation(media_id, conversation_name):
     try:

--- a/App_Function_Libraries/DB/SQLite_DB.py
+++ b/App_Function_Libraries/DB/SQLite_DB.py
@@ -2024,8 +2024,11 @@ def import_obsidian_note_to_db(note_data):
 #######################################################################################################################
 #
 # Chat-related Functions
+# FIXME - THESE ARE DEPRECATED!!!
 
+# DEAD CODE - TO BE REMOVED
 def create_chat_conversation(media_id, conversation_name):
+    # DEAD CODE - TO BE REMOVED
     try:
         with db.get_connection() as conn:
             cursor = conn.cursor()
@@ -2040,7 +2043,9 @@ def create_chat_conversation(media_id, conversation_name):
         raise DatabaseError(f"Error creating chat conversation: {e}")
 
 
+# DEAD CODE - FIXME
 def add_chat_message(conversation_id: int, sender: str, message: str) -> int:
+    # DEAD CODE - FIXME
     try:
         with db.get_connection() as conn:
             cursor = conn.cursor()
@@ -2055,7 +2060,9 @@ def add_chat_message(conversation_id: int, sender: str, message: str) -> int:
         raise DatabaseError(f"Error adding chat message: {e}")
 
 
+# FIXME - dead code
 def get_chat_messages(conversation_id: int) -> List[Dict[str, Any]]:
+    # FIXME - dead code
     try:
         with db.get_connection() as conn:
             cursor = conn.cursor()
@@ -2211,6 +2218,40 @@ def get_conversation_name(conversation_id):
     except Exception as e:
         logging.error(f"Unexpected error in get_conversation_name: {e}")
         return None
+
+###################################################
+#
+# DB Migration functions
+
+
+
+def get_all_conversations_from_media_db():
+    try:
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                SELECT id, media_id, media_name, conversation_name, created_at, updated_at
+                FROM ChatConversations
+            ''')
+            return cursor.fetchall()
+    except sqlite3.Error as e:
+        logging.error(f"Error retrieving conversations from media DB: {e}")
+        raise
+
+def get_messages_from_media_db(conversation_id):
+    try:
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                SELECT sender, message, timestamp
+                FROM ChatMessages
+                WHERE conversation_id = ?
+                ORDER BY timestamp ASC
+            ''', (conversation_id,))
+            return cursor.fetchall()
+    except sqlite3.Error as e:
+        logging.error(f"Error retrieving messages from media DB: {e}")
+        raise
 
 #
 # End of Chat-related Functions

--- a/App_Function_Libraries/Gradio_Related.py
+++ b/App_Function_Libraries/Gradio_Related.py
@@ -42,6 +42,7 @@ from App_Function_Libraries.Gradio_UI.Llamafile_tab import create_chat_with_llam
 from App_Function_Libraries.Gradio_UI.Media_edit import create_prompt_clone_tab, create_prompt_edit_tab, \
     create_media_edit_and_clone_tab, create_media_edit_tab
 from App_Function_Libraries.Gradio_UI.Media_wiki_tab import create_mediawiki_import_tab, create_mediawiki_config_tab
+from App_Function_Libraries.Gradio_UI.Mind_Map_tab import create_mindmap_tab
 from App_Function_Libraries.Gradio_UI.PDF_ingestion_tab import create_pdf_ingestion_tab, create_pdf_ingestion_test_tab
 from App_Function_Libraries.Gradio_UI.Plaintext_tab_import import create_plain_text_import_tab
 from App_Function_Libraries.Gradio_UI.Podcast_tab import create_podcast_tab
@@ -384,6 +385,7 @@ def launch_ui(share_public=None, server_mode=False):
                 # FIXME
                 #create_anki_generation_tab()
                 create_anki_validation_tab()
+                create_mindmap_tab()
                 create_utilities_yt_video_tab()
                 create_utilities_yt_audio_tab()
                 create_utilities_yt_timestamp_tab()

--- a/App_Function_Libraries/Gradio_Related.py
+++ b/App_Function_Libraries/Gradio_Related.py
@@ -25,8 +25,8 @@ from App_Function_Libraries.Gradio_UI.Character_Chat_tab import create_character
     create_character_card_validation_tab, create_export_characters_tab
 from App_Function_Libraries.Gradio_UI.Character_interaction_tab import create_narrator_controlled_conversation_tab, \
     create_multiple_character_chat_tab
-from App_Function_Libraries.Gradio_UI.Chat_ui import create_chat_management_tab, \
-    create_chat_interface_four, create_chat_interface_multi_api, create_chat_interface_stacked, create_chat_interface
+from App_Function_Libraries.Gradio_UI.Chat_ui import create_chat_interface_four, create_chat_interface_multi_api, \
+    create_chat_interface_stacked, create_chat_interface
 from App_Function_Libraries.Gradio_UI.Config_tab import create_config_editor_tab
 from App_Function_Libraries.Gradio_UI.Explain_summarize_tab import create_summarize_explain_tab
 from App_Function_Libraries.Gradio_UI.Export_Functionality import create_export_tab
@@ -460,7 +460,6 @@ def launch_ui(share_public=None, server_mode=False):
                 create_chat_interface_multi_api()
                 create_chat_interface_four()
                 create_chat_with_llamafile_tab()
-                create_chat_management_tab()
                 chat_workflows_tab()
 
             with gr.TabItem("Character Chat", id="character chat group", visible=True):

--- a/App_Function_Libraries/Gradio_UI/Anki_Testing_tab.py
+++ b/App_Function_Libraries/Gradio_UI/Anki_Testing_tab.py
@@ -1,0 +1,717 @@
+import gradio as gr
+import json
+import base64
+from datetime import datetime, timedelta
+from pathlib import Path
+import os
+from typing import Tuple, Optional, List, Dict, Any
+from dataclasses import dataclass
+from enum import Enum
+import re
+from contextlib import contextmanager
+import logging
+import sqlite3
+import uuid
+
+# Import existing functions from your Anki library
+from App_Function_Libraries.Third_Party.Anki import (
+    validate_flashcards,
+    sanitize_html,
+    process_apkg_file,
+    handle_file_upload as original_handle_file_upload,
+    enhanced_file_upload as original_enhanced_file_upload,
+    update_card_choices,
+    load_card_for_editing,
+    handle_validation,
+)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+
+
+class ReviewResult(Enum):
+    AGAIN = 1
+    HARD = 2
+    GOOD = 3
+    EASY = 4
+
+
+@dataclass
+class CardProgress:
+    card_id: str
+    last_reviewed: datetime
+    next_review: datetime
+    ease_factor: float
+    interval: int
+    review_count: int
+
+
+class DatabaseManager:
+    def __init__(self, db_path: str = "anki_progress.db"):
+        self.db_path = db_path
+        self.init_db()
+
+    @contextmanager
+    def get_connection(self) -> sqlite3.Connection:
+        """Context manager for database connections."""
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row  # Enable row factory for named columns
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def init_db(self) -> None:
+        """Initialize the database with enhanced schema."""
+        with self.get_connection() as conn:
+            try:
+                # Decks table with metadata
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS decks (
+                        deck_id TEXT PRIMARY KEY,
+                        deck_name TEXT NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        last_reviewed TIMESTAMP,
+                        card_count INTEGER,
+                        description TEXT,
+                        settings TEXT  -- JSON field for deck-specific settings
+                    )
+                """
+                )
+
+                # Cards table with enhanced media support
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS cards (
+                        card_id TEXT PRIMARY KEY,
+                        deck_id TEXT,
+                        front_content TEXT NOT NULL,
+                        back_content TEXT NOT NULL,
+                        card_type TEXT NOT NULL,
+                        tags TEXT,  -- JSON array of tags
+                        notes TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (deck_id) REFERENCES decks(deck_id) ON DELETE CASCADE
+                    )
+                """
+                )
+
+                # Media assets table
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS media_assets (
+                        asset_id TEXT PRIMARY KEY,
+                        card_id TEXT,
+                        content BLOB NOT NULL,
+                        media_type TEXT NOT NULL,
+                        filename TEXT NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (card_id) REFERENCES cards(card_id) ON DELETE CASCADE
+                    )
+                """
+                )
+
+                # Card progress tracking
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS card_progress (
+                        card_id TEXT PRIMARY KEY,
+                        deck_id TEXT,
+                        last_reviewed TIMESTAMP,
+                        next_review TIMESTAMP,
+                        ease_factor REAL DEFAULT 2.5,
+                        interval INTEGER DEFAULT 0,
+                        review_count INTEGER DEFAULT 0,
+                        review_history TEXT,  -- JSON array of review results
+                        FOREIGN KEY (card_id) REFERENCES cards(card_id) ON DELETE CASCADE,
+                        FOREIGN KEY (deck_id) REFERENCES decks(deck_id) ON DELETE CASCADE
+                    )
+                """
+                )
+
+                # Create indices for better performance
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_cards_deck ON cards(deck_id)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_media_card ON media_assets(card_id)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_progress_deck ON card_progress(deck_id)"
+                )
+
+                # Create full-text search virtual table
+                conn.execute(
+                    """
+                    CREATE VIRTUAL TABLE IF NOT EXISTS cards_fts USING fts5(
+                        front_content, back_content, tags, notes,
+                        content='cards',
+                        content_rowid='card_id'
+                    )
+                """
+                )
+
+                # Create triggers to update FTS table
+                conn.execute(
+                    """
+                    CREATE TRIGGER IF NOT EXISTS cards_ai AFTER INSERT ON cards BEGIN
+                        INSERT INTO cards_fts(rowid, front_content, back_content, tags, notes)
+                        VALUES (new.card_id, new.front_content, new.back_content, new.tags, new.notes);
+                    END;
+                """
+                )
+
+                conn.execute(
+                    """
+                    CREATE TRIGGER IF NOT EXISTS cards_au AFTER UPDATE ON cards BEGIN
+                        INSERT INTO cards_fts(cards_fts, rowid, front_content, back_content, tags, notes)
+                        VALUES('delete', old.card_id, old.front_content, old.back_content, old.tags, old.notes);
+                        INSERT INTO cards_fts(rowid, front_content, back_content, tags, notes)
+                        VALUES (new.card_id, new.front_content, new.back_content, new.tags, new.notes);
+                    END;
+                """
+                )
+
+                conn.execute(
+                    """
+                    CREATE TRIGGER IF NOT EXISTS cards_ad AFTER DELETE ON cards BEGIN
+                        INSERT INTO cards_fts(cards_fts, rowid, front_content, back_content, tags, notes)
+                        VALUES('delete', old.card_id, old.front_content, old.back_content, old.tags, old.notes);
+                    END;
+                """
+                )
+
+                conn.commit()
+            except Exception as e:
+                logging.exception("Error initializing database")
+                raise
+
+
+class DeckManager:
+    def __init__(self, db_path: str = "anki_progress.db"):
+        self.db = DatabaseManager(db_path)
+
+    def save_deck_from_json(self, deck_name: str, content: str, description: str = "") -> str:
+        try:
+            # Validate flashcards
+            is_valid, validation_message = validate_flashcards(content)
+            if not is_valid:
+                raise ValueError(validation_message)
+
+            deck_data = json.loads(content)
+            deck_id = str(uuid.uuid5(uuid.NAMESPACE_OID, deck_name))
+
+            with self.db.get_connection() as conn:
+                # Save deck metadata
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO decks 
+                    (deck_id, deck_name, card_count, description)
+                    VALUES (?, ?, ?, ?)
+                """,
+                    (deck_id, deck_name, len(deck_data["cards"]), description),
+                )
+
+                # Process each card
+                for card in deck_data["cards"]:
+                    # Sanitize content
+                    front_content = sanitize_html(card.get("front", ""))
+                    back_content = sanitize_html(card.get("back", ""))
+
+                    # Ensure all fields are strings
+                    card_id = str(card.get('id', ''))
+                    card_type = str(card.get('type', ''))
+                    tags_list = card.get('tags', [])
+                    if not isinstance(tags_list, list):
+                        tags_list = []
+                    else:
+                        tags_list = [str(tag) for tag in tags_list]
+                    tags = json.dumps(tags_list)
+                    notes = str(card.get('note', ''))
+
+                    # Debug statements
+                    logging.debug(f"Processing card with ID: {card_id}")
+                    logging.debug(
+                        f"Types: card_id={type(card_id)}, deck_id={type(deck_id)}, front_content={type(front_content)}, back_content={type(back_content)}, card_type={type(card_type)}, tags={type(tags)}, notes={type(notes)}")
+                    logging.debug(
+                        f"Values: card_id={card_id}, deck_id={deck_id}, front_content={front_content}, back_content={back_content}, card_type={card_type}, tags={tags}, notes={notes}")
+
+                    # Save card
+                    conn.execute(
+                        """
+                        INSERT OR REPLACE INTO cards 
+                        (card_id, deck_id, front_content, back_content, card_type, tags, notes)
+                        VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                        (
+                            card_id,
+                            deck_id,
+                            front_content,
+                            back_content,
+                            card_type,
+                            tags,
+                            notes,
+                        ),
+                    )
+
+                    # Initialize progress tracking
+                    conn.execute(
+                        """
+                        INSERT OR IGNORE INTO card_progress 
+                        (card_id, deck_id, review_history)
+                        VALUES (?, ?, '[]')
+                    """,
+                        (card_id, deck_id),
+                    )
+
+                conn.commit()
+                logging.info(
+                    f"Deck '{deck_name}' saved successfully with ID '{deck_id}'"
+                )
+            return deck_id
+        except Exception as e:
+            logging.exception("Error saving deck")
+            raise Exception("An error occurred while saving the deck.")
+
+    def get_deck_choices(self) -> List[str]:
+        """
+        Get a list of deck choices for dropdown menus.
+
+        Returns:
+            List[str]: List of deck names with IDs.
+        """
+        try:
+            with self.db.get_connection() as conn:
+                decks = conn.execute(
+                    """
+                    SELECT deck_id, deck_name FROM decks
+                """
+                ).fetchall()
+                return [
+                    f"{deck['deck_name']} ({deck['deck_id']})" for deck in decks
+                ]
+        except Exception as e:
+            logging.exception("Error retrieving deck choices")
+            return []
+
+
+class AnkiReviewInterface:
+    def __init__(self):
+        self.deck_manager = DeckManager()
+        self.current_card = None
+        self.review_queue = []
+        self.current_deck_id = None
+
+    def create_interface(self):
+        with gr.Blocks() as interface:
+            # Previous state variables
+            deck_select = gr.Dropdown(
+                choices=self.deck_manager.get_deck_choices(), label="Select Deck"
+            )
+            start_review_button = gr.Button("Start Review")
+
+            with gr.Tab("Review"):
+                with gr.Column():
+                    card_front = gr.HTML(label="Question")
+                    show_answer_button = gr.Button("Show Answer")
+                    card_back = gr.HTML(label="Answer", visible=False)
+                    with gr.Row(visible=False) as review_buttons_row:
+                        again_button = gr.Button("Again")
+                        hard_button = gr.Button("Hard")
+                        good_button = gr.Button("Good")
+                        easy_button = gr.Button("Easy")
+
+            # Import and create deck from JSON or APKG
+            with gr.Tab("Import Deck"):
+                gr.Markdown("## Import or Create Flashcards")
+
+                input_type = gr.Radio(
+                    choices=["JSON", "APKG"],
+                    label="Input Type",
+                    value="JSON"
+                )
+
+                with gr.Group() as json_input_group:
+                    flashcard_input = gr.TextArea(
+                        label="Enter Flashcards (JSON format)",
+                        placeholder='''{
+    "cards": [
+        {
+            "id": "CARD_001",
+            "type": "basic",
+            "front": "What is the capital of France?",
+            "back": "Paris",
+            "tags": ["geography", "europe"],
+            "note": "Remember: City of Light"
+        }
+    ]
+}''',
+                        lines=10
+                    )
+
+                    import_json = gr.File(
+                        label="Or Import JSON File",
+                        file_types=[".json"]
+                    )
+
+                with gr.Group(visible=False) as apkg_input_group:
+                    import_apkg = gr.File(
+                        label="Import APKG File",
+                        file_types=None  # Accept all file types
+                    )
+                    deck_info = gr.JSON(
+                        label="Deck Information",
+                        visible=False
+                    )
+
+                deck_name_input = gr.Textbox(
+                    label="Deck Name",
+                    placeholder="Enter a name for the deck"
+                )
+
+                description_input = gr.Textbox(
+                    label="Deck Description",
+                    placeholder="Optional description"
+                )
+
+                validate_button = gr.Button("Validate Flashcards")
+                validation_status = gr.Markdown("")
+
+                save_deck_button = gr.Button("Save Deck")
+
+            # Event handlers
+            input_type.change(
+                fn=lambda t: (
+                    gr.update(visible=t == "JSON"),
+                    gr.update(visible=t == "APKG"),
+                    gr.update(visible=t == "APKG")
+                ),
+                inputs=[input_type],
+                outputs=[json_input_group, apkg_input_group, deck_info]
+            )
+
+            # File upload handlers
+            import_json.upload(
+                fn=self.handle_file_upload,
+                inputs=[import_json, input_type],
+                outputs=[
+                    flashcard_input,
+                    deck_info,
+                    validation_status
+                ]
+            )
+
+            import_apkg.upload(
+                fn=self.handle_file_upload,
+                inputs=[import_apkg, input_type],
+                outputs=[
+                    flashcard_input,
+                    deck_info,
+                    validation_status
+                ]
+            )
+
+            # Validation handler
+            validate_button.click(
+                fn=lambda content, input_format: (
+                    handle_validation(content, input_format)
+                ),
+                inputs=[flashcard_input, input_type],
+                outputs=[validation_status]
+            )
+
+            # Save deck handler
+            save_deck_button.click(
+                fn=self.save_deck,
+                inputs=[deck_name_input, flashcard_input, description_input],
+                outputs=[deck_select, validation_status]
+            )
+
+            # Start review handlers
+            start_review_button.click(
+                self.start_review,
+                inputs=[deck_select],
+                outputs=[card_front, card_back, review_buttons_row, show_answer_button],
+            )
+
+            show_answer_button.click(
+                self.show_answer,
+                outputs=[card_back, review_buttons_row, show_answer_button],
+            )
+
+            again_button.click(
+                self.record_review,
+                inputs=[gr.State(ReviewResult.AGAIN)],
+                outputs=[card_front, card_back, review_buttons_row, show_answer_button],
+            )
+
+            hard_button.click(
+                self.record_review,
+                inputs=[gr.State(ReviewResult.HARD)],
+                outputs=[card_front, card_back, review_buttons_row, show_answer_button],
+            )
+
+            good_button.click(
+                self.record_review,
+                inputs=[gr.State(ReviewResult.GOOD)],
+                outputs=[card_front, card_back, review_buttons_row, show_answer_button],
+            )
+
+            easy_button.click(
+                self.record_review,
+                inputs=[gr.State(ReviewResult.EASY)],
+                outputs=[card_front, card_back, review_buttons_row, show_answer_button],
+            )
+
+        return interface
+
+    def handle_file_upload(self, file: Any, input_type: str) -> Tuple[Optional[str], Optional[Dict], str]:
+        """Handle file uploads and return appropriate outputs."""
+        if not file:
+            return None, None, "No file uploaded."
+
+        # Extract the file name and extension
+        if hasattr(file, 'name'):
+            filename = file.name
+        else:
+            filename = str(file)
+
+        if input_type == "APKG":
+            if not filename.lower().endswith('.apkg'):
+                return None, None, "Invalid file type. Please upload a .apkg file."
+
+            content, deck_info, message, _ = original_enhanced_file_upload(file, input_type)
+            if deck_info:
+                deck_info = deck_info  # Process deck_info if needed
+            else:
+                deck_info = None
+            return content, deck_info, message
+        else:
+            content, _, message, _ = original_handle_file_upload(file, input_type)
+            return content, None, message
+
+    def save_deck(self, deck_name: str, content: str, description: str):
+        """
+        Save the deck and update deck choices.
+
+        Args:
+            deck_name (str): The name of the deck.
+            content (str): The JSON content of the deck.
+            description (str): The deck description.
+
+        Returns:
+            Tuple[ComponentUpdate, str]: Updated deck choices and status message.
+        """
+        try:
+            deck_id = self.deck_manager.save_deck_from_json(deck_name, content, description)
+            deck_choices = self.deck_manager.get_deck_choices()
+            # Update the deck_select Dropdown choices
+            return gr.update(choices=deck_choices), f"Deck '{deck_name}' saved successfully!"
+        except Exception as e:
+            logging.exception("Error saving deck")
+            return gr.update(), "An error occurred while saving the deck."
+
+    def start_review(self, deck_choice: str):
+        """
+        Start the review session for the selected deck.
+
+        Args:
+            deck_choice (str): The selected deck from the dropdown.
+
+        Returns:
+            Tuple[HTML, HTML, Component, Component]: Updated components.
+        """
+        try:
+            if not deck_choice:
+                return (
+                    gr.update(value="Please select a deck."),
+                    "",
+                    gr.update(visible=False),
+                    gr.update(visible=False),
+                )
+
+            # Extract deck_id from deck_choice
+            deck_id = deck_choice.split("(")[-1].strip(")")
+
+            with self.deck_manager.db.get_connection() as conn:
+                # Get cards due for review
+                today = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                cards = conn.execute(
+                    """
+                    SELECT c.front_content, c.back_content, c.card_id
+                    FROM cards c
+                    JOIN card_progress p ON c.card_id = p.card_id
+                    WHERE p.deck_id = ?
+                    AND (p.next_review IS NULL OR p.next_review <= ?)
+                    ORDER BY p.next_review ASC
+                """,
+                    (deck_id, today),
+                ).fetchall()
+
+            if not cards:
+                return (
+                    gr.update(value="No cards due for review."),
+                    "",
+                    gr.update(visible=False),
+                    gr.update(visible=False),
+                )
+
+            self.review_queue = list(cards)
+            self.current_deck_id = deck_id
+
+            # Load the first card
+            self.current_card = self.review_queue.pop(0)
+            front_content = self.current_card["front_content"]
+
+            return front_content, "", gr.update(visible=False), gr.update(visible=True)
+        except Exception as e:
+            logging.exception("Error starting review")
+            return (
+                "An error occurred while starting the review.",
+                "",
+                gr.update(visible=False),
+                gr.update(visible=False),
+            )
+
+    def show_answer(self):
+        """
+        Show the answer for the current card.
+
+        Returns:
+            Tuple[HTML, Component, Component]: Updated components.
+        """
+        try:
+            if not self.current_card:
+                return "", gr.update(visible=False), gr.update(visible=False)
+
+            back_content = self.current_card["back_content"]
+            return back_content, gr.update(visible=True), gr.update(visible=False)
+        except Exception as e:
+            logging.exception("Error showing answer")
+            return (
+                "An error occurred while showing the answer.",
+                gr.update(visible=False),
+                gr.update(visible=False),
+            )
+
+    def record_review(self, review_result: ReviewResult):
+        """
+        Record the review result and load the next card.
+
+        Args:
+            review_result (ReviewResult): The result of the review.
+
+        Returns:
+            Tuple[HTML, HTML, Component, Component]: Updated components.
+        """
+        try:
+            if not self.current_card:
+                return "", "", gr.update(visible=False), gr.update(visible=False)
+
+            card_id = self.current_card["card_id"]
+            self.update_card_progress(card_id, review_result)
+
+            if self.review_queue:
+                self.current_card = self.review_queue.pop(0)
+                front_content = self.current_card["front_content"]
+                return front_content, "", gr.update(visible=False), gr.update(visible=True)
+            else:
+                # No more cards
+                self.current_card = None
+                return (
+                    "Review session completed.",
+                    "",
+                    gr.update(visible=False),
+                    gr.update(visible=False),
+                )
+        except Exception as e:
+            logging.exception("Error recording review")
+            return (
+                "An error occurred while recording the review.",
+                "",
+                gr.update(visible=False),
+                gr.update(visible=False),
+            )
+
+    def update_card_progress(self, card_id: str, review_result: ReviewResult):
+        """
+        Update the card's progress based on the review result.
+
+        Args:
+            card_id (str): The ID of the card.
+            review_result (ReviewResult): The result of the review.
+        """
+        try:
+            with self.deck_manager.db.get_connection() as conn:
+                progress = conn.execute(
+                    """
+                    SELECT * FROM card_progress WHERE card_id = ?
+                """,
+                    (card_id,),
+                ).fetchone()
+
+                if not progress:
+                    logging.error(f"Progress not found for card_id {card_id}")
+                    return
+
+                # Update progress based on SM-2 algorithm
+                ease_factor = progress["ease_factor"]
+                interval = progress["interval"]
+                review_count = progress["review_count"]
+
+                if review_result == ReviewResult.AGAIN:
+                    interval = 1
+                    ease_factor = max(1.3, ease_factor - 0.2)
+                elif review_result == ReviewResult.HARD:
+                    interval = max(1, int(interval * 1.2))
+                    ease_factor = max(1.3, ease_factor - 0.15)
+                elif review_result == ReviewResult.GOOD:
+                    interval = max(1, int(interval * ease_factor))
+                elif review_result == ReviewResult.EASY:
+                    interval = max(1, int(interval * ease_factor * 1.3))
+                    ease_factor = min(2.5, ease_factor + 0.15)
+
+                next_review_date = datetime.now() + timedelta(days=interval)
+                review_history = (
+                    json.loads(progress["review_history"])
+                    if progress["review_history"]
+                    else []
+                )
+                review_history.append(
+                    {
+                        "timestamp": datetime.now().isoformat(),
+                        "result": review_result.name,
+                    }
+                )
+
+                conn.execute(
+                    """
+                    UPDATE card_progress
+                    SET last_reviewed = ?, next_review = ?, ease_factor = ?, interval = ?, review_count = ?, review_history = ?
+                    WHERE card_id = ?
+                """,
+                    (
+                        datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        next_review_date.strftime("%Y-%m-%d %H:%M:%S"),
+                        ease_factor,
+                        interval,
+                        review_count + 1,
+                        json.dumps(review_history),
+                        card_id,
+                    ),
+                )
+                conn.commit()
+        except Exception as e:
+            logging.exception("Error updating card progress")
+
+
+def main():
+    interface = AnkiReviewInterface()
+    review_interface = interface.create_interface()
+    review_interface.launch()
+
+
+if __name__ == "__main__":
+    main()

--- a/App_Function_Libraries/Gradio_UI/Character_Chat_tab.py
+++ b/App_Function_Libraries/Gradio_UI/Character_Chat_tab.py
@@ -21,7 +21,7 @@ import gradio as gr
 from App_Function_Libraries.Character_Chat.Character_Chat_Lib import validate_character_book, validate_v2_card, \
     replace_placeholders, replace_user_placeholder, extract_json_from_image, parse_character_book, \
     load_chat_and_character, load_chat_history, load_character_and_image, extract_character_id, load_character_wrapper
-from App_Function_Libraries.Chat import chat
+from App_Function_Libraries.Chat.Chat_Functions import chat, approximate_token_count
 from App_Function_Libraries.DB.Character_Chat_DB import (
     add_character_card,
     get_character_cards,
@@ -36,8 +36,6 @@ from App_Function_Libraries.DB.Character_Chat_DB import (
 )
 from App_Function_Libraries.Utils.Utils import sanitize_user_input, format_api_name, global_api_endpoints, \
     default_api_endpoint
-
-
 #
 ############################################################################################################
 #
@@ -317,6 +315,7 @@ def create_character_card_interaction_tab():
                 answer_for_me_button = gr.Button("Answer for Me")
                 continue_talking_button = gr.Button("Continue Talking")
                 regenerate_button = gr.Button("Regenerate Last Message")
+                token_count_display = gr.Number(label="Approximate Token Count", value=0, interactive=False)
                 clear_chat_button = gr.Button("Clear Chat")
                 save_snapshot_button = gr.Button("Save Chat Snapshot")
                 update_chat_dropdown = gr.Dropdown(label="Select Chat to Update", choices=[], visible=False)
@@ -881,6 +880,10 @@ def create_character_card_interaction_tab():
                 auto_save_checkbox
             ],
             outputs=[chat_history, save_status]
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chat_history],
+            outputs=[token_count_display]
         )
 
         continue_talking_button.click(
@@ -895,6 +898,10 @@ def create_character_card_interaction_tab():
                 auto_save_checkbox
             ],
             outputs=[chat_history, save_status]
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chat_history],
+            outputs=[token_count_display]
         )
 
         import_card_button.click(
@@ -913,6 +920,10 @@ def create_character_card_interaction_tab():
             fn=clear_chat_history,
             inputs=[character_data, user_name_input],
             outputs=[chat_history, character_data]
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chat_history],
+            outputs=[token_count_display]
         )
 
         character_dropdown.change(
@@ -938,7 +949,13 @@ def create_character_card_interaction_tab():
                 auto_save_checkbox
             ],
             outputs=[chat_history, save_status]
-        ).then(lambda: "", outputs=user_input)
+        ).then(
+            lambda: "", outputs=user_input
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chat_history],
+            outputs=[token_count_display]
+        )
 
         regenerate_button.click(
             fn=regenerate_last_message,
@@ -952,6 +969,10 @@ def create_character_card_interaction_tab():
                 auto_save_checkbox
             ],
             outputs=[chat_history, save_status]
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chat_history],
+            outputs=[token_count_display]
         )
 
         import_chat_button.click(
@@ -961,8 +982,12 @@ def create_character_card_interaction_tab():
 
         chat_file_upload.change(
             fn=import_chat_history,
-            inputs=[chat_file_upload, chat_history, character_data],
+            inputs=[chat_file_upload, chat_history, character_data, user_name_input],
             outputs=[chat_history, character_data, save_status]
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chat_history],
+            outputs=[token_count_display]
         )
 
         save_chat_history_to_db.click(
@@ -1019,6 +1044,10 @@ def create_character_card_interaction_tab():
             fn=load_selected_chat_from_search,
             inputs=[chat_search_dropdown, user_name_input],
             outputs=[character_data, chat_history, character_image, save_status]
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chat_history],
+            outputs=[token_count_display]
         )
 
         # Show Load Chat Button when a chat is selected

--- a/App_Function_Libraries/Gradio_UI/Character_interaction_tab.py
+++ b/App_Function_Libraries/Gradio_UI/Character_interaction_tab.py
@@ -17,7 +17,7 @@ import gradio as gr
 from PIL import Image
 #
 # Local Imports
-from App_Function_Libraries.Chat import chat, load_characters, save_chat_history_to_db_wrapper
+from App_Function_Libraries.Chat.Chat_Functions import chat, load_characters, save_chat_history_to_db_wrapper
 from App_Function_Libraries.Gradio_UI.Chat_ui import chat_wrapper
 from App_Function_Libraries.Gradio_UI.Writing_tab import generate_writing_feedback
 from App_Function_Libraries.Utils.Utils import default_api_endpoint, format_api_name, global_api_endpoints

--- a/App_Function_Libraries/Gradio_UI/Chat_Workflows.py
+++ b/App_Function_Libraries/Gradio_UI/Chat_Workflows.py
@@ -11,7 +11,7 @@ import gradio as gr
 #
 from App_Function_Libraries.Gradio_UI.Chat_ui import chat_wrapper, search_conversations, \
     load_conversation
-from App_Function_Libraries.Chat import save_chat_history_to_db_wrapper
+from App_Function_Libraries.Chat.Chat_Functions import save_chat_history_to_db_wrapper
 from App_Function_Libraries.Utils.Utils import default_api_endpoint, global_api_endpoints, format_api_name
 
 #

--- a/App_Function_Libraries/Gradio_UI/Chat_Workflows.py
+++ b/App_Function_Libraries/Gradio_UI/Chat_Workflows.py
@@ -1,5 +1,5 @@
 # Chat_Workflows.py
-# Description: UI for Chat Workflows
+# Description: Gradio UI for Chat Workflows
 #
 # Imports
 import json
@@ -9,11 +9,11 @@ from pathlib import Path
 # External Imports
 import gradio as gr
 #
+# Local Imports
 from App_Function_Libraries.Gradio_UI.Chat_ui import chat_wrapper, search_conversations, \
     load_conversation
 from App_Function_Libraries.Chat.Chat_Functions import save_chat_history_to_db_wrapper
 from App_Function_Libraries.Utils.Utils import default_api_endpoint, global_api_endpoints, format_api_name
-
 #
 ############################################################################################################
 #
@@ -74,6 +74,7 @@ def chat_workflows_tab():
                 clear_btn = gr.Button("Clear Chat")
                 chat_media_name = gr.Textbox(label="Custom Chat Name(optional)")
                 save_btn = gr.Button("Save Chat to Database")
+                save_status = gr.Textbox(label="Save Status", interactive=False)
 
         def update_workflow_ui(workflow_name):
             if not workflow_name:
@@ -164,7 +165,7 @@ def chat_workflows_tab():
         save_btn.click(
             save_chat_history_to_db_wrapper,
             inputs=[chatbot, conversation_id, media_content, chat_media_name],
-            outputs=[conversation_id, gr.Textbox(label="Save Status")]
+            outputs=[conversation_id, save_status]
         )
 
         search_conversations_btn.click(

--- a/App_Function_Libraries/Gradio_UI/Chat_ui.py
+++ b/App_Function_Libraries/Gradio_UI/Chat_ui.py
@@ -13,14 +13,12 @@ from datetime import datetime
 import gradio as gr
 #
 # Local Imports
-from App_Function_Libraries.Chat import chat, save_chat_history, update_chat_content, save_chat_history_to_db_wrapper
-from App_Function_Libraries.Chat.Chat_Functions import approximate_token_count
+from App_Function_Libraries.Chat.Chat_Functions import approximate_token_count, chat, save_chat_history, \
+    update_chat_content, save_chat_history_to_db_wrapper
 from App_Function_Libraries.DB.DB_Manager import add_chat_message, search_chat_conversations, create_chat_conversation, \
     get_chat_messages, update_chat_message, delete_chat_message, load_preset_prompts, db
 from App_Function_Libraries.Gradio_UI.Gradio_Shared import update_dropdown, update_user_prompt
 from App_Function_Libraries.Utils.Utils import default_api_endpoint, format_api_name, global_api_endpoints
-
-
 #
 #
 ########################################################################################################################
@@ -201,6 +199,7 @@ def regenerate_last_message(history, media_content, selected_parts, api_endpoint
     new_history.append((last_user_message, bot_message))
 
     return new_history, "Last message regenerated successfully."
+
 
 def create_chat_interface():
     try:
@@ -511,6 +510,7 @@ def create_chat_interface_stacked():
             with gr.Column():
                 submit = gr.Button("Submit")
                 regenerate_button = gr.Button("Regenerate Last Message")
+                token_count_display = gr.Number(label="Approximate Token Count", value=0, interactive=False)
                 clear_chat_button = gr.Button("Clear Chat")
                 chat_media_name = gr.Textbox(label="Custom Chat Name(optional)", visible=True)
                 save_chat_history_to_db = gr.Button("Save Chat History to DataBase")
@@ -532,10 +532,14 @@ def create_chat_interface_stacked():
                 gr.update(value=prompts["system_prompt"], visible=True)
             )
 
+        def clear_chat():
+            return [], None, 0  # Empty history, conversation_id, and token count
+
         clear_chat_button.click(
             clear_chat,
-            outputs=[chatbot, conversation_id]
+            outputs=[chatbot, conversation_id, token_count_display]
         )
+
         preset_prompt.change(
             update_prompts,
             inputs=preset_prompt,
@@ -547,13 +551,17 @@ def create_chat_interface_stacked():
             inputs=[msg, chatbot, media_content, selected_parts, api_endpoint, api_key, user_prompt,
                     conversation_id, save_conversation, temp, system_prompt],
             outputs=[msg, chatbot, conversation_id]
-        ).then(  # Clear the message box after submission
+        ).then(
             lambda x: gr.update(value=""),
             inputs=[chatbot],
             outputs=[msg]
-        ).then(  # Clear the user prompt after the first message
+        ).then(
             lambda: gr.update(value=""),
             outputs=[user_prompt, system_prompt]
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chatbot],
+            outputs=[token_count_display]
         )
 
         items_output.change(
@@ -606,6 +614,10 @@ def create_chat_interface_stacked():
             regenerate_last_message,
             inputs=[chatbot, media_content, selected_parts, api_endpoint, api_key, user_prompt, temp, system_prompt],
             outputs=[chatbot, gr.Textbox(label="Regenerate Status")]
+        ).then(
+            lambda history: approximate_token_count(history),
+            inputs=[chatbot],
+            outputs=[token_count_display]
         )
 
 
@@ -656,6 +668,7 @@ def create_chat_interface_multi_api():
             api_keys = []
             temperatures = []
             regenerate_buttons = []
+            token_count_displays = []
             for i in range(3):
                 with gr.Column():
                     gr.Markdown(f"### Chat Window {i + 1}")
@@ -669,6 +682,9 @@ def create_chat_interface_multi_api():
                     temperature = gr.Slider(label=f"Temperature {i + 1}", minimum=0.0, maximum=1.0, step=0.05,
                                             value=0.7)
                     chatbot = gr.Chatbot(height=800, elem_classes="chat-window")
+                    token_count_display = gr.Number(label=f"Approximate Token Count {i + 1}", value=0,
+                                                    interactive=False)
+                    token_count_displays.append(token_count_display)
                     regenerate_button = gr.Button(f"Regenerate Last Message {i + 1}")
                     chatbots.append(chatbot)
                     api_endpoints.append(api_endpoint)
@@ -696,14 +712,14 @@ def create_chat_interface_multi_api():
 
         preset_prompt.change(update_user_prompt, inputs=preset_prompt, outputs=user_prompt)
 
-
         def clear_all_chats():
-            return [[]] * 3 + [[]] * 3
+            return [[]] * 3 + [[]] * 3 + [0] * 3
 
         clear_chat_button.click(
             clear_all_chats,
-            outputs=chatbots + chat_history
+            outputs=chatbots + chat_history + token_count_displays
         )
+
         def chat_wrapper_multi(message, custom_prompt, system_prompt, *args):
             chat_histories = args[:3]
             chatbots = args[3:6]
@@ -733,6 +749,11 @@ def create_chat_interface_multi_api():
 
             return [gr.update(value="")] + new_chatbots + new_chat_histories
 
+        def update_token_counts(*histories):
+            token_counts = []
+            for history in histories:
+                token_counts.append(approximate_token_count(history))
+            return token_counts
 
         def regenerate_last_message(chat_history, chatbot, media_content, selected_parts, api_endpoint, api_key, custom_prompt, temperature, system_prompt):
             if not chat_history:
@@ -769,8 +790,13 @@ def create_chat_interface_multi_api():
         for i in range(3):
             regenerate_buttons[i].click(
                 regenerate_last_message,
-                inputs=[chat_history[i], chatbots[i], media_content, selected_parts, api_endpoints[i], api_keys[i], user_prompt, temperatures[i], system_prompt],
+                inputs=[chat_history[i], chatbots[i], media_content, selected_parts, api_endpoints[i], api_keys[i],
+                        user_prompt, temperatures[i], system_prompt],
                 outputs=[chatbots[i], chat_history[i], gr.Textbox(label=f"Regenerate Status {i + 1}")]
+            ).then(
+                lambda history: approximate_token_count(history),
+                inputs=[chat_history[i]],
+                outputs=[token_count_displays[i]]
             )
 
         # In the create_chat_interface_multi_api function:
@@ -783,6 +809,10 @@ def create_chat_interface_multi_api():
         ).then(
             lambda: (gr.update(value=""), gr.update(value="")),
             outputs=[msg, user_prompt]
+        ).then(
+            update_token_counts,
+            inputs=chat_history,
+            outputs=token_count_displays
         )
 
         items_output.change(
@@ -797,7 +827,6 @@ def create_chat_interface_multi_api():
                 inputs=[use_content, use_summary, use_prompt],
                 outputs=[selected_parts]
             )
-
 
 
 def create_chat_interface_four():
@@ -864,7 +893,10 @@ def create_chat_interface_four():
                 msg = gr.Textbox(label=f"Enter your message for Chat {index + 1}")
                 submit = gr.Button(f"Submit to Chat {index + 1}")
                 regenerate_button = gr.Button(f"Regenerate Last Message {index + 1}")
+                token_count_display = gr.Number(label=f"Approximate Token Count {index + 1}", value=0,
+                                                interactive=False)
                 clear_chat_button = gr.Button(f"Clear Chat {index + 1}")
+
 
                 # State to maintain chat history
                 chat_history = gr.State([])
@@ -879,7 +911,8 @@ def create_chat_interface_four():
                     'submit': submit,
                     'regenerate_button': regenerate_button,
                     'clear_chat_button': clear_chat_button,
-                    'chat_history': chat_history
+                    'chat_history': chat_history,
+                    'token_count_display': token_count_display
                 })
 
         # Create four chat interfaces arranged in a 2x2 grid
@@ -973,6 +1006,10 @@ def create_chat_interface_four():
                     interface['chatbot'],
                     interface['chat_history']
                 ]
+            ).then(
+                lambda history: approximate_token_count(history),
+                inputs=[interface['chat_history']],
+                outputs=[interface['token_count_display']]
             )
 
             interface['regenerate_button'].click(
@@ -989,13 +1026,20 @@ def create_chat_interface_four():
                     interface['chat_history'],
                     gr.Textbox(label="Regenerate Status")
                 ]
+            ).then(
+                lambda history: approximate_token_count(history),
+                inputs=[interface['chat_history']],
+                outputs=[interface['token_count_display']]
             )
 
-            interface['clear_chat_button'].click(
-                clear_chat_single,
-                inputs=[],
-                outputs=[interface['chatbot'], interface['chat_history']]
-            )
+            def clear_chat_single():
+                return [], [], 0
+
+            for interface in chat_interfaces:
+                interface['clear_chat_button'].click(
+                    clear_chat_single,
+                    outputs=[interface['chatbot'], interface['chat_history'], interface['token_count_display']]
+                )
 
 
 def chat_wrapper_single(message, chat_history, chatbot, api_endpoint, api_key, temperature, media_content,

--- a/App_Function_Libraries/Gradio_UI/Mind_Map_tab.py
+++ b/App_Function_Libraries/Gradio_UI/Mind_Map_tab.py
@@ -1,0 +1,128 @@
+# Mind_Map_tab.py
+# Description: File contains functions for generation of PlantUML mindmaps for the gradio tab
+#
+# Imports
+import re
+#
+# External Libraries
+import gradio as gr
+#
+######################################################################################################################
+#
+# Functions:
+
+def parse_plantuml_mindmap(plantuml_text: str) -> dict:
+    """Parse PlantUML mindmap syntax into a nested dictionary structure"""
+    lines = [line.strip() for line in plantuml_text.split('\n')
+             if line.strip() and not line.strip().startswith('@')]
+
+    root = None
+    nodes = []
+    stack = []
+
+    for line in lines:
+        level_match = re.match(r'^([+\-*]+|\*+)', line)
+        if not level_match:
+            continue
+        level = len(level_match.group(0))
+        text = re.sub(r'^([+\-*]+|\*+)\s*', '', line).strip('[]').strip('()')
+        node = {'text': text, 'children': []}
+
+        while stack and stack[-1][0] >= level:
+            stack.pop()
+
+        if stack:
+            stack[-1][1]['children'].append(node)
+        else:
+            root = node
+
+        stack.append((level, node))
+
+    return root
+
+def create_mindmap_html(plantuml_text: str) -> str:
+    """Convert PlantUML mindmap to HTML visualization with collapsible nodes using CSS only"""
+    # Parse the mindmap text into a nested structure
+    root_node = parse_plantuml_mindmap(plantuml_text)
+    if not root_node:
+        return "<p>No valid mindmap content provided.</p>"
+
+    html = "<style>"
+    html += """
+    details {
+        margin-left: 20px;
+    }
+    summary {
+        cursor: pointer;
+        padding: 5px;
+        border: 1px solid #333;
+        border-radius: 3px;
+        background-color: #e6f3ff;
+    }
+    .mindmap-node {
+        margin-left: 20px;
+        padding: 5px;
+        border: 1px solid #333;
+        border-radius: 3px;
+    }
+    """
+    html += "</style>"
+
+    colors = ['#e6f3ff', '#f0f7ff', '#f5f5f5', '#fff0f0', '#f0fff0']
+
+    def create_node_html(node, level):
+        bg_color = colors[(level - 1) % len(colors)]
+        if node['children']:
+            children_html = ''.join(create_node_html(child, level + 1) for child in node['children'])
+            return f"""
+            <details open>
+                <summary style="background-color: {bg_color};">{node['text']}</summary>
+                {children_html}
+            </details>
+            """
+        else:
+            return f"""
+            <div class="mindmap-node" style="background-color: {bg_color}; margin-left: {level * 20}px;">
+                {node['text']}
+            </div>
+            """
+
+    html += create_node_html(root_node, level=1)
+    return html
+
+# Create Gradio interface
+def create_mindmap_tab():
+    with gr.TabItem():
+        gr.Markdown("# Collapsible PlantUML Mindmap Visualizer")
+        gr.Markdown("Convert PlantUML mindmap syntax to a visual mindmap with collapsible nodes.")
+        plantuml_input = gr.Textbox(
+            lines=15,
+            label="Enter PlantUML mindmap",
+            placeholder="""@startmindmap
+    * Project Planning
+    ** Requirements
+    *** Functional Requirements
+    **** User Interface
+    **** Backend Services
+    *** Technical Requirements
+    **** Performance
+    **** Security
+    ** Timeline
+    *** Phase 1
+    *** Phase 2
+    ** Resources
+    *** Team
+    *** Budget
+    @endmindmap"""
+        )
+        submit_btn = gr.Button("Generate Mindmap")
+        mindmap_output = gr.HTML(label="Mindmap Output")
+        submit_btn.click(
+            fn=create_mindmap_html,
+            inputs=plantuml_input,
+            outputs=mindmap_output
+        )
+
+#
+# End of Mind_Map_tab.py
+######################################################################################################################

--- a/App_Function_Libraries/Gradio_UI/Mind_Map_tab.py
+++ b/App_Function_Libraries/Gradio_UI/Mind_Map_tab.py
@@ -92,7 +92,7 @@ def create_mindmap_html(plantuml_text: str) -> str:
 
 # Create Gradio interface
 def create_mindmap_tab():
-    with gr.TabItem():
+    with gr.TabItem("PlantUML Mindmap"):
         gr.Markdown("# Collapsible PlantUML Mindmap Visualizer")
         gr.Markdown("Convert PlantUML mindmap syntax to a visual mindmap with collapsible nodes.")
         plantuml_input = gr.Textbox(

--- a/App_Function_Libraries/Gradio_UI/Prompt_Suggestion_tab.py
+++ b/App_Function_Libraries/Gradio_UI/Prompt_Suggestion_tab.py
@@ -5,7 +5,7 @@ import logging
 
 import gradio as gr
 
-from App_Function_Libraries.Chat import chat
+from App_Function_Libraries.Chat.Chat_Functions import chat
 from App_Function_Libraries.DB.SQLite_DB import add_or_update_prompt
 from App_Function_Libraries.Prompt_Engineering.Prompt_Engineering import generate_prompt, test_generated_prompt
 from App_Function_Libraries.Utils.Utils import format_api_name, global_api_endpoints, default_api_endpoint

--- a/App_Function_Libraries/Prompt_Engineering/Prompt_Engineering.py
+++ b/App_Function_Libraries/Prompt_Engineering/Prompt_Engineering.py
@@ -4,7 +4,7 @@
 # Imports
 import re
 
-from App_Function_Libraries.Chat import chat_api_call
+from App_Function_Libraries.Chat.Chat_Functions import chat_api_call
 #
 # Local Imports
 #

--- a/Docs/Issues/ISSUES.md
+++ b/Docs/Issues/ISSUES.md
@@ -29,3 +29,8 @@ Create a blog post
 
 Linux Cuda
      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/user/venv/lib/python3.X/site-packages/nvidia/cudnn/lib/
+
+
+Export/Import From google keep
+	https://takeout.google.com/
+	https://github.com/djsudduth/keep-it-markdown

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - **Full Plaintext & RAG Search Capability** Search across all ingested content via RAG or 'old-fashioned non-LLM search' (RAG being BM25 + Vector Search/Contextual embeddings + Re-ranking + Contextual Retrieval).
   - Search by content, title, author, URL, or tags, with support for meta-tags, so that you can have the equivalent of 'folders' for your content (and tags).
   - If you'd like to see my notes on RAG: see `./Docs/RAG_Notes.md`
+  - Notes support, ala NotebookLM, so you can keep track of your thoughts and ideas while chatting/learning, with the ability to search across them or use them for RAG.
 - **Local LLM inference for offline usage and chat** - via `llamafile`/`HuggingFace Transformers`.
 - **4 Different Chat UI styles** - Regular chat, Stacked chat, Multi-Response chat(1 Prompt, 3 APIs) and 4 Separate API chats on one page.
 - **Local Embeddings Generation for RAG Search** - via `llamafile`/`llama.cpp`/`HuggingFace Transformers`.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,27 @@
 
 
 #### Key Features:
-- Full-text+RAG search across all ingested content (RAG being BM25 + Vector Search/Contextual embeddings + Re-ranking).
-- Local LLM inference for offline usage and chat (via `llamafile`/`HuggingFace Transformers`).
-- Local Embeddings generation for RAG search (via `llamafile`/`llama.cpp`/`HuggingFace Transformers`).
-- Build up a personal knowledge archive, then turn around and use the LLM to help you learn it at a pace your comfortable with.
+- Ingest(Transcribe/convert to markdown) content from (multiple) URLs or local files (video, audio, documents, web articles, books, mediawiki dumps) -> Summarize/Analyze -> Chat with/about the content.- Build up a personal knowledge archive, then turn around and use the LLM to help you learn it at a pace your comfortable with.
+- **Full Plaintext & RAG Search Capability** Search across all ingested content via RAG or 'old-fashioned non-LLM search' (RAG being BM25 + Vector Search/Contextual embeddings + Re-ranking + Contextual Retrieval).
+  - Search by content, title, author, URL, or tags, with support for meta-tags, so that you can have the equivalent of 'folders' for your content (and tags).
+  - If you'd like to see my notes on RAG: see `./Docs/RAG_Notes.md`
+- **Local LLM inference for offline usage and chat** - via `llamafile`/`HuggingFace Transformers`.
+- **4 Different Chat UI styles** - Regular chat, Stacked chat, Multi-Response chat(1 Prompt, 3 APIs) and 4 Separate API chats on one page.
+- **Local Embeddings Generation for RAG Search** - via `llamafile`/`llama.cpp`/`HuggingFace Transformers`.
 - Also writing tools! Grammar/Style checker, Tone Analyzer, Writing editor(feedback), and more.
-- Full Character Chat Support - Create/Edit & Import/Export Character Cards, and chat with them.
+- **Full Character Chat Support** - Create/Edit & Import/Export Character Cards, and chat with them.
+- **Arxiv API Integration** - Search and ingest papers from Arxiv.
+- **Chat Workflows** - A way to string together multiple questions and responses into a single chat. - Use it to create a 'workflow' for a specific task. Configured via a JSON file.
+- **Import Obsidian Notes/Vault** - Import Obsidian Vaults into the DB. (Imported notes are automatically parsed for tags and titles)
+- **Backup Management** - A way to back up the DBs, view backups, and restore from a backup. (4 SQLite DBs: Media, Character Chats, RAG Chats, Embeddings)
+- **Trashcan Support** - A way to 'soft' delete content, and restore it if needed. (Helps with accidental deletions) - Trashcan is only for the MediaDB.
+- **Support for 7 Local LLM APIs:** `Llama.cpp`, `Kobold.cpp`, `Oobabooga`, `TabbyAPI`, `vLLM`, Ollama`.
+- **Support for 8 Commercial APIs:** `Claude Sonnet 3.5`, `Cohere Command R+`, `DeepSeek`, `Groq`, `HuggingFace`, `Mistral`, `OpenAI`, `OpenRouter`.
+- **Local Audio Recording with Transcription** - Record audio locally and transcribe it.
+- **Structured Prompt Creation and Management** - Create prompts using a structured approach, and then edit and use them in your chats. Or delete them.
+  - Also have the ability to import prompts individually or in bulk. As well as export them as markdown documents.
+  - See `./Docs/Prompts/` for examples of prompts. and `./Docs/Propmts/TEMPLATE.md` for the prompt template used in tldw.
+- Features to come: Anki Flashcard creation, Mindmap creation from content(currently in under `Utilities`, uses PlantUML), better document handling, migration to a FastAPI backend, and more.
 #### The original scripts by `the-crypt-keeper` for transcribing and summarizing youtube videos are available here: [scripts here](https://github.com/the-crypt-keeper/tldw/tree/main/tldw-original-scripts)
 
 
@@ -321,16 +336,14 @@ You can view the full roadmap on the [GitHub Issues page](https://github.com/rmu
 - These are just the 'standard smaller' models I recommend, there are many more out there, and you can use any of them with this project.
   - One should also be aware that people create 'fine-tunes' and 'merges' of existing models, to create new models that are more suited to their needs.
   - This can result in models that may be better at some tasks but worse at others, so it's important to test and see what works best for you.
-- MS Phi-3.5-mini-128k(32k effective context, censored output): https://huggingface.co/bartowski/Phi-3.5-mini-instruct-GGUF
-  - Fine-tuned to be uncensored somewhat: https://huggingface.co/bartowski/Phi-3.5-mini-instruct_Uncensored-GGUF
-- AWS MegaBeam Mistral (32k effective context): https://huggingface.co/bartowski/MegaBeam-Mistral-7B-512k-GGUF
-- Mistral Nemo Instruct 2407 - https://huggingface.co/QuantFactory/Mistral-Nemo-Instruct-2407-GGUF
 - Llama 3.1 - The native llamas will give you censored output by default, but you can jailbreak them, or use a finetune which has attempted to tune out their refusals. 
   - 8B: https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF 
+- Mistral Nemo Instruct 2407 - https://huggingface.co/QuantFactory/Mistral-Nemo-Instruct-2407-GGUF
+- AWS MegaBeam Mistral (32k effective context): https://huggingface.co/bartowski/MegaBeam-Mistral-7B-512k-GGUF
 - Mistral Small: https://huggingface.co/bartowski/Mistral-Small-Instruct-2409-GGUF
 - Cohere Command-R
   - Command-R https://huggingface.co/bartowski/c4ai-command-r-v01-GGUF / Aug2024 version: https://huggingface.co/bartowski/c4ai-command-r-08-2024-GGUF
-- Qwen 2.5 Series(haven't tested these ones yet but they seem promising, almost certainly censored): https://huggingface.co/collections/Qwen/qwen25-66e81a666513e518adb90d9e
+- Qwen 2.5 Series(Pretty powerful, less pop-culture knowledge and censored somewhat): https://huggingface.co/collections/Qwen/qwen25-66e81a666513e518adb90d9e
   - 2.5-3B: https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF
   - 7B: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct-GGUF
   - 14B: https://huggingface.co/Qwen/Qwen2.5-14B-Instruct-GGUF

--- a/Tests/SQLite_DB/test_chat_functions.py
+++ b/Tests/SQLite_DB/test_chat_functions.py
@@ -1,23 +1,20 @@
 import pytest
 from App_Function_Libraries.DB.DB_Manager import (
-    create_chat_conversation,
-    add_chat_message,
-    get_chat_messages,
     update_chat_message,
     delete_chat_message,
-    search_chat_conversations,
-    get_conversation_name
+    search_chat_conversations, save_message, load_chat_history
 )
+from App_Function_Libraries.DB.RAG_QA_Chat_DB import start_new_conversation
 
 
 @pytest.fixture
 def sample_conversation(empty_db):
-    conversation_id = create_chat_conversation(None, "Test Conversation")
+    conversation_id = start_new_conversation("Test Conversation", None)
     return conversation_id
 
 
-def test_create_chat_conversation(empty_db):
-    conversation_id = create_chat_conversation(None, "Test Conversation")
+def test_start_new_conversation(empty_db):
+    conversation_id = start_new_conversation("Test Conversation", None)
     assert conversation_id is not None
     assert isinstance(conversation_id, int)
 
@@ -26,46 +23,46 @@ def test_create_chat_conversation(empty_db):
     # assert name == "Test Conversation"
 
 
-def test_add_chat_message(empty_db, sample_conversation):
-    message_id = add_chat_message(sample_conversation, "user", "Hello, world!")
+def test_save_message(empty_db, sample_conversation):
+    message_id = save_message(conversation_id=sample_conversation, role="user", content="Hello, world!")
     assert message_id is not None
     assert isinstance(message_id, int)
 
 
-def test_get_chat_messages(empty_db, sample_conversation):
-    add_chat_message(sample_conversation, "user", "Hello, world!")
-    add_chat_message(sample_conversation, "ai", "Hi there!")
-    messages = get_chat_messages(sample_conversation)
+def test_load_chat_history(empty_db, sample_conversation):
+    save_message(conversation_id=sample_conversation, role="user", content="Hello, world!")
+    save_message(conversation_id=sample_conversation, role="ai", content="Hi there!")
+    messages = load_chat_history(sample_conversation)
     assert len(messages) == 2
     assert messages[0]['message'] == "Hello, world!"
     assert messages[1]['message'] == "Hi there!"
 
 
 def test_update_chat_message(empty_db, sample_conversation):
-    message_id = add_chat_message(sample_conversation, "user", "Hello, world!")
+    message_id = save_message(conversation_id=sample_conversation, role="user", content="Hello, world!")
     update_chat_message(message_id, "Updated message")
-    messages = get_chat_messages(sample_conversation)
+    messages = load_chat_history(sample_conversation)
     assert len(messages) == 1
     assert messages[0]['message'] == "Updated message"
 
 
 def test_delete_chat_message(empty_db, sample_conversation):
-    message_id = add_chat_message(sample_conversation, "user", "Hello, world!")
+    message_id = save_message(conversation_id=sample_conversation, role="user", content="Hello, world!")
     delete_chat_message(message_id)
-    messages = get_chat_messages(sample_conversation)
+    messages = load_chat_history(sample_conversation)
     assert len(messages) == 0
 
 
 def test_search_chat_conversations(empty_db):
     # Create conversations with names that will match our search queries
-    conv1_id = create_chat_conversation(None, "World Conversation")
-    conv2_id = create_chat_conversation(None, "Python Discussion")
-    conv3_id = create_chat_conversation(None, "Test Conversation")
+    conv1_id = start_new_conversation("World Conversation", None)
+    conv2_id = start_new_conversation("Python Discussion", None)
+    conv3_id = start_new_conversation("Test Conversation", None)
 
     # Add messages (these won't affect the search results based on the current implementation)
-    add_chat_message(conv1_id, "user", "Hello, world!")
-    add_chat_message(conv2_id, "user", "Python is great")
-    add_chat_message(conv3_id, "user", "This is a test message")
+    save_message(conversation_id=conv1_id, role="user", content="Hello, world!")
+    save_message(conversation_id=conv2_id, role="user", content="Python is great")
+    save_message(conv3_id, "user", "This is a test message")
 
     print(f"Created conversations: {conv1_id}, {conv2_id}, {conv3_id}")
 
@@ -100,3 +97,7 @@ def test_search_chat_conversations(empty_db):
     found_conversations = set(result['id'] for result in all_results)
     assert new_conversation_ids.issubset(
         found_conversations), "All newly created conversations should be in the search results"
+
+#
+# End of test_chat_functions.py
+#######################################################################################################################


### PR DESCRIPTION
Split chats from the Media DB so that chats about media items are now stored in the RAG_QA db.
This allows the media DB to solely contain media items/info about them while the RAG_QA db will store all non-rp chats.
This furthers the idea of isolation between all components for re-usability and plug-n-play.

Added Mindmap viewing in Gradio from PlantUML specification. Generate a spec, copy/paste it in, and you got a mindmap.

Added token counts to conversations, rough approximation (not actually tokenizing) to get an idea of how long your convo is.

Added an Anki flashcard validation(working)/viewing(broken) functionality so that you can validate(?) your deck is good(?) 
Plan is to look at implementing generation with genanki and LLMs so that you can be guided through/ask the LLM to help generate a structured output to be able to create anki flashcards that are exportable/reviewable.