### PR TITLE
Add optional TwelveLabs Pegasus rolling video summary backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ YouTube contains an incredible amount of knowledge, much of which is locked insi
 - `roller-*.py` - rolling summarization
   - [can-ai-code](https://github.com/the-crypt-keeper/can-ai-code) - interview executors to run LLM inference
 
+- `roller-pegasus.py` - rolling summarization from the *video itself* (optional)
+  - [TwelveLabs Pegasus](https://twelvelabs.io) - video-understanding model; summarizes what is on screen, not just the transcript. Reads the source URL from `<prefix>.info.json` and analyzes it in rolling time-windows. Needs `pip install twelvelabs fire jinja2` and `TWELVELABS_API_KEY` (free tier available).
+
 - `compare.py` - prepare LLM outputs for webapp
 - `compare-app.py` - summary viewer webapp
 

--- a/roller-pegasus.py
+++ b/roller-pegasus.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Rolling video summarization backend using TwelveLabs Pegasus.
+#
+# Unlike the other roller-*.py backends, this one does NOT summarize the
+# diarized transcript - it summarizes the video itself. Pegasus is a
+# video-understanding model, so it sees what is on screen, not just what is
+# said. To handle arbitrarily long videos despite the per-request 1 hour
+# analyze limit, the video is analyzed in rolling time-windows, each window
+# carrying forward a running context just like the other rollers.
+#
+# Setup:
+#   pip install twelvelabs fire jinja2
+#   export TWELVELABS_API_KEY=...   # free tier: https://twelvelabs.io
+#
+# Usage mirrors the other rollers - point it at a prefix that has a
+# <prefix>.info.json (produced by diarize.py). It writes <prefix>.summary.json
+# in the same line-per-section format the other rollers use. The source video
+# is fetched server-side from the info.json webpage_url, so it must be a
+# publicly accessible URL (or pass --video_url=).
+import json
+import os
+
+instruction = """Continue the rolling summary of the video "{{title}}".
+Consider the running context below when summarizing this segment, which covers
+{{ start|round|int }}s to {{ end|round|int }}s of the video.
+
+### Context: {{ context }}
+
+Respond ONLY with a JSON object with 2 keys in the following format:
+{
+ "Summary": "A detailed, point-by-point summary of what happens in this segment of the video. Describe what is shown and what is said. Write at least three sentences and no more than six sentences. ALWAYS maintain third person.",
+ "Next-Context": "An updated context for the next segment. List the current topics and any people identified so far."
+}
+"""
+
+
+def main(prefix: str,
+         model_name: str = "pegasus1.5",
+         window: int = 600,
+         max_tokens: int = 2048,
+         video_url: str = ""):
+    """Summarize a video with TwelveLabs Pegasus in rolling time-windows.
+
+    prefix:     path prefix; reads <prefix>.info.json, writes <prefix>.summary.json
+    model_name: pegasus1.5 (default; required for time-window analyze)
+    window:     seconds per rolling analyze window (must be <= 3600)
+    video_url:  override the source URL (defaults to info.json webpage_url)
+    """
+    from jinja2 import Template
+    from twelvelabs import TwelveLabs
+    from twelvelabs.types.video_context import VideoContext_Url
+
+    if window > 3600:
+        raise ValueError("window must be <= 3600s (Pegasus analyze caps at 1 hour per request)")
+
+    api_key = os.environ.get("TWELVELABS_API_KEY")
+    if not api_key:
+        raise RuntimeError("TWELVELABS_API_KEY is not set (free key: https://twelvelabs.io)")
+
+    info = json.load(open(prefix + '.info.json'))
+    title = info['title']
+    url = video_url or info.get('webpage_url') or info.get('original_url')
+    if not url:
+        raise RuntimeError("no video URL: pass video_url= or ensure info.json has webpage_url")
+    duration = info.get('duration')
+
+    client = TwelveLabs(api_key=api_key)
+    video = VideoContext_Url(url=url)
+
+    the_template = Template(instruction)
+    context = f'Title: "{title}"\nTopics: [ "UNKNOWN" ]'
+
+    # Without a known duration we cannot window, so do a single full-video pass.
+    if not duration:
+        windows = [(0.0, None)]
+    else:
+        windows = [(float(s), float(min(s + window, duration)))
+                   for s in range(0, int(duration), window)]
+
+    f = open(prefix + '.summary.json', 'w')
+    for idx, (start, end) in enumerate(windows):
+        print(f"{idx}: {start}s -> {end}s")
+        prompt = the_template.render(title=title, context=context, start=start, end=end or 0)
+
+        res = client.analyze(
+            model_name=model_name,
+            video=video,
+            prompt=prompt,
+            temperature=0.2,
+            max_tokens=max_tokens,
+            start_time=start,
+            end_time=end,
+        )
+        answer = res.data or ''
+        if not answer.endswith('}'):
+            answer += '}'
+
+        try:
+            parsed = json.loads(answer, strict=False)
+        except Exception as e:
+            print(answer)
+            print('Error parsing response: ', str(e))
+            parsed = {}
+
+        summary = parsed.get('Summary', '')
+        new_context = str(parsed.get('Next-Context', ''))
+
+        if summary == '' or new_context == '':
+            print('extraction failed:', new_context, summary)
+            exit(1)
+
+        section = {
+            'start': start,
+            'end': end if end is not None else (duration or start),
+            'summary': summary,
+            'speakers': '{}',  # Pegasus summarizes video, not diarized speakers
+            'context': new_context,
+        }
+        print('>> ', new_context)
+        print(summary)
+        print()
+
+        f.write(json.dumps(section) + '\n')
+        f.flush()
+
+        context = new_context
+
+
+if __name__ == "__main__":
+    import fire
+    fire.Fire(main)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds `roller-pegasus.py`, a new optional summarization backend that sits alongside the existing `roller-*.py` scripts.

**What it does**
- Summarizes the *video itself* using TwelveLabs Pegasus (a video-understanding model) instead of the diarized transcript, so it captures what is shown on screen, not just what is said.
- Handles arbitrarily long videos by analyzing them in rolling time-windows (Pegasus' analyze call caps at 1 hour per request), carrying a running context forward between windows exactly like the other rollers.
- Reads the source URL from `<prefix>.info.json` (the `webpage_url` yt-dlp already writes) and emits `<prefix>.summary.json` in the same line-per-section format `compare.py` / `compare-app.py` already consume — no downstream changes needed.

**Why it helps**
For long talks/podcasts where the visuals matter (slides, demos, on-screen text), a transcript-only summary misses a lot. This gives a drop-in video-native alternative without changing any existing behavior.

**Opt-in / non-breaking**
Pure addition. No existing file or default is touched; the new dependency (`twelvelabs`) is only imported inside `roller-pegasus.py` and only used if you run that script.

**How it was tested**
Ran the full rolling loop end-to-end against the live API on a short public sample clip with `--window 5` to exercise multiple windows and context carry-forward — it produced valid `summary.json` sections. Verified against `twelvelabs` SDK 1.2.8 (Pegasus 1.5 is required for the time-window analyze used here).

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.